### PR TITLE
Command line arguments support added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINARY=topdeb
 
 CC=g++ -g
 
-LIBS=-lboost_system -lboost_filesystem
+LIBS=-lboost_system -lboost_filesystem -lboost_program_options
 
 CCXXFLAGS=-std=c++0x
 

--- a/dpkg.cpp
+++ b/dpkg.cpp
@@ -14,13 +14,15 @@ using namespace std;
 namespace {
   const path dpkg_path("/var/lib/dpkg/info");
   const string list_ext(".list");
-  const unsigned int topPkgs = 50;
-  const string outputfile ("topdeb.out");
   const boost::posix_time::seconds freq(1);
   const boost::posix_time::seconds zero_freq(0);
 };
 
-dpkg::dpkg(boost::asio::io_service& io_service) : m_timer(io_service, zero_freq)
+dpkg::dpkg(boost::asio::io_service& io_service, settings& sett) 
+  : m_timer(io_service, zero_freq),
+  fileToPackage(),
+  top_list(),
+  sett(sett)
 {
   _loadFileLists();
   add_handle();
@@ -38,10 +40,10 @@ void dpkg::openfile(string path)
 
 void dpkg::dumpTop()
 {
-  auto loops = topPkgs;
+  auto loops = sett.top_packages;
   auto node = packages_list.front();
   std::ofstream ofile;
-  ofile.open(outputfile);
+  ofile.open(sett.output_file);
   while (loops > 0 && node->next) {
     ofile << node->value.first << endl;
     node = node->next;

--- a/dpkg.h
+++ b/dpkg.h
@@ -6,10 +6,11 @@
 #include <list>
 #include <boost/asio.hpp>
 #include "dllist.h"
+#include "settings.h"
 
 class dpkg {
   public:
-    dpkg(boost::asio::io_service&);
+    dpkg(boost::asio::io_service&, settings& sett);
     void openfile(std::string path);
     void dumpTop();
 
@@ -25,7 +26,7 @@ class dpkg {
     typedef dlnodelist<pkgUsage>* pkg_list_node;
     std::unordered_map<std::string, pkg_list_node>  fileToPackage;
     std::list<pkg_list_node> top_list;
-
+    settings& sett;
 };
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -1,26 +1,65 @@
 #include "dpkg.h"
 #include "systemtap.h"
 #include "dllist.h"
+#include "settings.h"
 #include <iostream>
 #include <thread>
 #include <unistd.h>
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
+#include <boost/program_options.hpp>
 
-int main() {
+namespace po = boost::program_options;
+
+bool parse_command_line(int argc, char* argv[], settings* sett) {
+  po::options_description desc("Allowed options");
+  bool ret = true;
+
+  desc.add_options()
+    ("help", "produce help message")
+    ("output_file", po::value<std::string>(), "filename full path")
+    ("top_packages", po::value<unsigned int>(), "number of top packages");
+
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, argv, desc), vm);
+  po::notify(vm);
+
+  if(vm.count("help")) {
+    std::cout << desc << std::endl;
+    ret = false;
+  }
+
+  if(vm.count("output_file")) {
+    sett->output_file = vm["output_file"].as<std::string>();
+  }
+
+  if(vm.count("top_packages")) {
+    sett->top_packages = vm["top_packages"].as<unsigned int>();
+  }
+
+  return ret;
+}
+
+int main(int argc, char* argv[]) {
+  settings sett;
+
+  if(!parse_command_line(argc, argv, &sett))
+  {
+    exit(EXIT_SUCCESS);
+  }
+
   boost::asio::io_service io_service;
 
-  dpkg packages(io_service);
+  dpkg packages(io_service, sett);
 
   systemtap files(
       io_service,
       [&] (std::string line) { packages.openfile(line); } 
    );
-   
+
   if (!files.start()) {
    exit(-1);
   }
 
   io_service.run();
 }
-

--- a/settings.h
+++ b/settings.h
@@ -1,0 +1,14 @@
+#ifndef SETTINGS_H
+#define SETTINGS_H
+
+#include <string>
+
+struct settings
+{
+  std::string output_file;
+  unsigned int top_packages;
+
+  settings() : output_file("/tmp/topdeb.out"), top_packages(50) {}
+};
+
+#endif


### PR DESCRIPTION
A new struct settings was added to store two command line arguments:
- output_file
- top_packages

To parse command line arguments boost::program_options library was used
adding a function to main.cpp to do parsing stuff.

A settings reference attribute was added to dpkg class.
Now this class uses settings reference to access to output_file and
top_packages values now.
