### PR TITLE
Command line arguments support added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINARY=topdeb
 
 CC=g++ -g
 
-LIBS=-lboost_system -lboost_filesystem
+LIBS=-lboost_system -lboost_filesystem -lboost_program_options
 
 CCXXFLAGS=-std=c++0x
 

--- a/dpkg.cpp
+++ b/dpkg.cpp
@@ -14,13 +14,15 @@ using namespace std;
 namespace {
   const path dpkg_path("/var/lib/dpkg/info");
   const string list_ext(".list");
-  const unsigned int topPkgs = 50;
-  const string outputfile ("topdeb.out");
   const boost::posix_time::seconds freq(1);
   const boost::posix_time::seconds zero_freq(0);
 };
 
-dpkg::dpkg(boost::asio::io_service& io_service) : m_timer(io_service, zero_freq)
+dpkg::dpkg(boost::asio::io_service& io_service, settings& sett) 
+  : m_timer(io_service, zero_freq),
+  file_to_package(),
+  top_list(),
+  sett(sett)
 {
   load_filelists();
   add_handle();
@@ -38,10 +40,10 @@ void dpkg::open_file(string path)
 
 void dpkg::dump_top()
 {
-  auto loops = topPkgs;
+  auto loops = sett.top_packages;
   auto node = packages_list.front();
   std::ofstream ofile;
-  ofile.open(outputfile);
+  ofile.open(sett.output_file);
   while (loops > 0 && node->next) {
     ofile << node->value.first << endl;
     node = node->next;

--- a/dpkg.h
+++ b/dpkg.h
@@ -6,10 +6,11 @@
 #include <list>
 #include <boost/asio.hpp>
 #include "dllist.h"
+#include "settings.h"
 
 class dpkg {
   public:
-    dpkg(boost::asio::io_service&);
+    dpkg(boost::asio::io_service&, settings& sett);
     void open_file(std::string path);
     void dump_top();
 
@@ -25,7 +26,7 @@ class dpkg {
     typedef dlnodelist<pkg_usage>* pkg_list_node;
     std::unordered_map<std::string, pkg_list_node>  file_to_package;
     std::list<pkg_list_node> top_list;
-
+    settings& sett;
 };
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -1,24 +1,71 @@
 #include "dpkg.h"
 #include "systemtap.h"
 #include "dllist.h"
+#include "settings.h"
 #include <iostream>
 #include <unistd.h>
 #include <boost/asio.hpp>
+#include <boost/bind.hpp>
+#include <boost/program_options.hpp>
 
-int main() {
+namespace po = boost::program_options;
+
+bool parse_command_line(int argc, char* argv[], settings& sett) {
+  po::options_description desc("Allowed options");
+
+  desc.add_options()
+    ("help,h", "produce help message")
+    ("outfile,o", po::value<std::string>(), "filename full path")
+    ("top-pkgs,t", po::value<unsigned int>(), "number of top packages");
+
+  po::variables_map vm;
+
+  try {
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+  } catch (const boost::program_options::unknown_option& ex) {
+    std::cout << ex.what() << std::endl;
+    std::cout << desc << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  po::notify(vm);
+
+  if(vm.count("help")) {
+    std::cout << desc << std::endl;
+    return false;;
+  }
+
+  if(vm.count("outfile")) {
+    sett.output_file = vm["outfile"].as<std::string>();
+  }
+
+  if(vm.count("top-pkgs")) {
+    sett.top_packages = vm["top-pkgs"].as<unsigned int>();
+  }
+
+  return true;
+}
+
+int main(int argc, char* argv[]) {
+  settings sett;
+
+  if(!parse_command_line(argc, argv, sett))
+  {
+    exit(EXIT_SUCCESS);
+  }
+
   boost::asio::io_service io_service;
 
-  dpkg packages(io_service);
+  dpkg packages(io_service, sett);
 
   systemtap files(
       io_service,
       [&] (std::string line) { packages.open_file(line); } 
    );
-   
+
   if (!files.start()) {
    exit(-1);
   }
 
   io_service.run();
 }
-

--- a/settings.h
+++ b/settings.h
@@ -1,0 +1,14 @@
+#ifndef SETTINGS_H
+#define SETTINGS_H
+
+#include <string>
+
+struct settings
+{
+  std::string output_file;
+  unsigned int top_packages;
+
+  settings() : output_file("/tmp/topdeb.out"), top_packages(50) {}
+};
+
+#endif


### PR DESCRIPTION
A new struct settings was added to store two command line arguments:
- outfile
- top-pkgs

To parse command line arguments boost::program_options library was used
adding a function to main.cpp to do parsing stuff.

A settings reference attribute was added to dpkg class.
Now this class uses settings reference to access to output_file and
top_packages values now.
