### PR TITLE
Logging support using std::clog integrated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SOURCE=main.cpp dpkg.cpp systemtap.cpp
+SOURCE=main.cpp dpkg.cpp systemtap.cpp log.cpp
 BINARY=topdeb
 
 CC=g++ -g

--- a/logger.cpp
+++ b/logger.cpp
@@ -1,0 +1,49 @@
+#include "log.h"
+
+logging::log_streambuf::log_streambuf(
+    std::string ident, 
+    const logging::facility& facility
+  ) : 
+    m_buffer(),
+    m_facility(facility),
+    m_priority(logging::priority::debug),
+    m_ident(ident)
+{
+  openlog(m_ident.c_str(), LOG_PID, static_cast<int>(m_facility));
+}
+
+int logging::log_streambuf::sync()
+{
+  if(m_buffer.length())
+  {
+    syslog(static_cast<int>(m_priority), m_buffer.c_str());
+    m_buffer.erase();
+    m_priority = logging::priority::debug;
+  }
+
+  return 0;
+}
+
+int logging::log_streambuf::overflow(int c)
+{
+  if(c != EOF)
+  {
+    m_buffer += static_cast<char>(c);
+  } 
+  else
+  {
+    sync();
+  }
+
+  return c;
+}
+
+std::ostream& logging::operator<<(
+    std::ostream& os,
+    const logging::priority& priority
+  )
+{
+  static_cast<logging::log_streambuf*>(os.rdbuf())->m_priority = priority;
+
+  return os;
+}

--- a/logger.h
+++ b/logger.h
@@ -1,0 +1,93 @@
+#ifndef LOG_H
+#define LOG_H
+
+// A modified version of Log class from:
+// http://stackoverflow.com/a/4457138
+
+#include <syslog.h>
+#include <iostream>
+
+namespace logging {
+
+  // See man 3 syslog for details
+  enum class priority {
+      emerg   = LOG_EMERG,
+      alert   = LOG_ALERT,
+      crit    = LOG_CRIT,
+      err     = LOG_ERR,
+      warning = LOG_WARNING,
+      notice  = LOG_NOTICE,
+      info    = LOG_INFO,
+      debug   = LOG_DEBUG
+  };
+  
+  // See man 3 syslog for details
+  enum class facility {
+      user      = LOG_USER,
+      mail      = LOG_MAIL,
+      daemon    = LOG_DAEMON,
+      auth      = LOG_AUTH,
+      syslog    = LOG_SYSLOG,
+      lpr       = LOG_LPR,
+      news      = LOG_NEWS,
+      uucp      = LOG_UUCP,
+      cron      = LOG_CRON,
+      authpriv  = LOG_AUTHPRIV,
+      ftp       = LOG_FTP,
+      local0    = LOG_LOCAL0,
+      local1    = LOG_LOCAL1,
+      local2    = LOG_LOCAL2,
+      local3    = LOG_LOCAL3,
+      local4    = LOG_LOCAL4,
+      local5    = LOG_LOCAL5,
+      local6    = LOG_LOCAL6,
+      local7    = LOG_LOCAL7
+  };
+
+  std::ostream& operator<<(std::ostream& os, const logging::priority& priority);
+
+  class log_streambuf
+      : public std::basic_streambuf<char, std::char_traits<char>>
+  {
+    public:
+      explicit log_streambuf(std::string ident, const logging::facility& facility);
+
+    protected:
+      int sync();
+      int overflow(int c);
+
+    private:
+      friend std::ostream& operator<<(
+          std::ostream& os,
+          const logging::priority& priority
+        );
+
+      std::string m_buffer;
+      logging::facility m_facility;
+      logging::priority m_priority;
+      std::string m_ident;
+  };
+
+  class logger
+  {
+    public:
+      explicit logger(std::string ident, const logging::facility& facility)
+        : 
+          m_log_streambuf(ident, facility),
+          m_old_clog_streambuf(nullptr)
+      {
+        m_old_clog_streambuf = std::clog.rdbuf(&m_log_streambuf);
+      }
+
+      ~logger()
+      {
+        std::clog.rdbuf(m_old_clog_streambuf);
+      }
+
+    private:
+      logging::log_streambuf m_log_streambuf;
+      std::streambuf* m_old_clog_streambuf;
+  };
+}
+
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,8 @@
 #include "systemtap.h"
 #include "dllist.h"
 #include "settings.h"
+#include "log.h"
+
 #include <iostream>
 #include <unistd.h>
 #include <boost/asio.hpp>
@@ -47,6 +49,10 @@ bool parse_command_line(int argc, char* argv[], settings& sett) {
 }
 
 int main(int argc, char* argv[]) {
+  logging::logger mylog("topdeb", logging::facility::daemon);
+
+  std::clog << "topdeb launched" << std::endl;
+
   settings sett;
 
   if(!parse_command_line(argc, argv, sett))


### PR DESCRIPTION
A new logger class was added, it uses RAII idiom to change std::clog streambuf
by a log_streambuf pointer. When logger instance goes out of scope it
destructor is called and std::clog gets his old streambuf pointer.

log_streambuf class inherits from basic_streambuf and implements streambuf
functionality through syslog calls. It wraps the use of C syslog.h
functionality into streambuf class and encapsulates facility and priority macro
values into C++11 enum classes.

An instance of logger was added at main function with logger::facility::daemon
constructor attribute. This produce that all std::clog uses goes to
/var/log/daemon.log
